### PR TITLE
Fix processor_id generation for a Contact in Credit Note

### DIFF
--- a/includes/credits.php
+++ b/includes/credits.php
@@ -92,7 +92,7 @@ function edd_quaderno_create_credit( $payment_id, $new_status, $old_status ) {
 			'vat_number' => $metadata['vat_number'],
 			'tax_id' => $metadata['tax_id'],
 			'processor' => 'edd',
-			'processor_id' => $payment->customer_id
+			'processor_id' => strtotime($customer->date_created) . '_' . $payment->customer_id
 		);
 	}
 


### PR DESCRIPTION
When the data of a contact is sent to Quaderno associated to a Credit note, the processor_id field is generated in a different way than when it is sent associated to an Invoice.

We should use the same format in both cases. `strtotime($customer->date_created) . '_' . $payment->customer_id`