### PR TITLE
Base the transaction item amount on the subtotal minus discount.

### DIFF
--- a/includes/invoices.php
+++ b/includes/invoices.php
@@ -167,7 +167,7 @@ function edd_quaderno_create_invoice($payment_id, $parent_id = 0) {
 		$download = new EDD_Download( $cart_item['id'] );
 
 		// Calculate discount rate (if it exists)
-    $discount_rate = 0;
+		$discount_rate = 0;
 		if ( $cart_item['discount'] > 0 ) {
 			$discount_rate = $cart_item['discount'] / $cart_item['subtotal'] * 100;
 		}
@@ -176,8 +176,8 @@ function edd_quaderno_create_invoice($payment_id, $parent_id = 0) {
 			'product_code' => $download->post_name,
 			'description' => get_quaderno_payment_description( $cart_item, $payment->transaction_id ),
 			'quantity' => $cart_item['quantity'],
-			'amount' => $cart_item['price'],
-      'discount_rate' => $discount_rate,
+			'amount' => $cart_item['subtotal'] - $cart_item['discount'],
+			'discount_rate' => $discount_rate,
 			'tax' => $tax
 		);
 


### PR DESCRIPTION
This patch proposes to set the transaction item amount sent to Quaderno as a difference between the cart item subtotal and the discount rather than the cart item price. The reason for this is to resolve a conflict with the [EDD Discounts Pro](https://easydigitaldownloads.com/downloads/discounts-pro/) extension. 

The default EDD discounts (discount coupons) are stored in the `cart_item['discount']` element and 'cart_item['price']` element contains the discounted price. All is well here. 

However, the EDD Discounts Pro implements the discounts as negative payment fees instead. In this case, `cart_item['discount']` is 0 and the negative payment fees get added to the Quaderno invoice in the payment fees for loop. The issue is that `cart_item['price']` is still the discounted price and as a result the invoice in Quaderno lists both the discounted item and the negative fee as a separate item. This essentially results in double discount being applied and a wrong total invoice amount. 

This can be avoided by setting the transaction item amount as a difference between `$cart_item['subtotal']` and `$cart_item['discount']`. For the items with the normal EDD discount coupon applied this has no impact, because `cart_item['price']` is calculated as the difference between the item subtotal and discount. And it fixes the double discount for the items with the Discounts Pro discount, because the `cart_item['subtotal']` is the full price, `cart_item['discount']` is 0 and the discount gets added to the invoice in the fees for loop. 

I hope the above makes sense. It's a bit complicated to explain, so don't hesitate to shoot questions or ask for clarification if you have any.

Thanks!