### PR TITLE
Added support for paypal_commerce gateway

### DIFF
--- a/includes/payments.php
+++ b/includes/payments.php
@@ -29,6 +29,7 @@ function get_quaderno_payment_method( $gateway ) {
       $method = 'credit_card';
       break;
     case 'paypal':
+    case 'paypal_commerce':
       $method = 'paypal';
       break;
     default:


### PR DESCRIPTION
PayPal Commerce gateway wasn't properly matched with Quaderno's PayPal method.

![Bildschirm­foto 2023-03-22 um 09 46 51](https://user-images.githubusercontent.com/2278756/226850342-7914960b-e7e3-49d2-a3cf-ec550ce80556.png)
