### PR TITLE
When reading order meta data, use payment_meta as fallback

### DIFF
--- a/edd-quaderno.php
+++ b/edd-quaderno.php
@@ -4,7 +4,7 @@
  * Plugin Name: EDD Quaderno
  * Plugin URI: https://wordpress.org/plugins/edd-quaderno/
  * Description: Automatically send customizable sales receipts and invoices with every order in your Easy Digital Downloads store.
- * Version: 1.33.1
+ * Version: 1.33.2
  * Author: Quaderno
  * Author URI: https://www.quaderno.io/integrations/easy-digital-downloads?utm_source=wordpress&utm_campaign=edd
  * License: GPL v3

--- a/includes/business_fields.php
+++ b/includes/business_fields.php
@@ -167,13 +167,13 @@ add_action('edd_built_order', 'edd_quaderno_store_business_data', 100);
 function edd_quaderno_show_business_data( $order_id ) {
   $order = edd_get_order( $order_id );
 
-  $tax_id = edd_get_order_meta( $order_id, 'vat_number', true );
+  $tax_id = edd_quaderno_get_order_meta( $order_id, 'vat_number', true );
   if( empty( $tax_id ) ) {
-    $tax_id = edd_get_order_meta( $order_id, 'tax_id', true );
+    $tax_id = edd_quaderno_get_order_meta( $order_id, 'tax_id', true );
   }
 
   // Get the current business name
-  $business_name = edd_get_order_meta( $order_id, 'business_name', true );
+  $business_name = edd_quaderno_get_order_meta( $order_id, 'business_name', true );
 
 	?>
   <div class="order-data-address">

--- a/includes/credits.php
+++ b/includes/credits.php
@@ -27,12 +27,12 @@ function edd_quaderno_create_credit( $order_id, $refund_id, $all_refunded ) {
 	$refund = edd_get_order( $refund_id );
 
 	// Return if the original order hasn't generate an invoice on Quaderno
-	if ( empty( edd_get_order_meta( $order_id, '_quaderno_invoice_id', true ) ) ) {
+	if ( empty( edd_quaderno_get_order_meta( $order_id, '_quaderno_invoice_id', true ) ) ) {
 		return;
 	}
 
 	// Return if a credit has already been issued for this order
-	if ( !empty( edd_get_order_meta( $refund_id, '_quaderno_credit_id', true ) ) ) {
+	if ( !empty( edd_quaderno_get_order_meta( $refund_id, '_quaderno_credit_id', true ) ) ) {
 		return;
 	}
 
@@ -48,7 +48,7 @@ function edd_quaderno_create_credit( $order_id, $refund_id, $all_refunded ) {
 		'interval_count' => $order->parent_payment == 0 ? '0' : '1',
 		'notes' => apply_filters( 'quaderno_credit_notes', $tax->notes, $order, $tax ),
 		'processor' => 'edd',
-		'processor_id' => edd_get_order_meta( $order_id, '_quaderno_processor_id', true ),
+		'processor_id' => edd_quaderno_get_order_meta( $order_id, '_quaderno_processor_id', true ),
 		'payment' => array(
 			'method' => get_quaderno_payment_method( $order->gateway ),
       'processor' => $order->gateway,
@@ -63,7 +63,7 @@ function edd_quaderno_create_credit( $order_id, $refund_id, $all_refunded ) {
 	$tax = edd_quaderno_tax( $order->address->country,
 													 $order->address->postal_code,
 													 $order->address->city,
-													 edd_get_order_meta( $order_id, 'tax_id', true ) );
+													 edd_quaderno_get_order_meta( $order_id, 'tax_id', true ) );
 
   // Calculate transaction items and tags
 	$transaction_items = array();

--- a/includes/invoices.php
+++ b/includes/invoices.php
@@ -37,8 +37,8 @@ function edd_quaderno_create_invoice( $payment_id ) {
 	}
 
 	// Get tax ID & business name
-	$tax_id = edd_get_order_meta( $payment_id, 'tax_id', true );
-	$business_name = edd_get_order_meta( $payment_id, 'business_name', true );
+	$tax_id = edd_quaderno_get_order_meta( $payment_id, 'tax_id', true );
+	$business_name = edd_quaderno_get_order_meta( $payment_id, 'business_name', true );
 	
 	// Get the taxes
 	$tax = edd_quaderno_tax( $payment->address['country'], $payment->address['zip'], $payment->address['city'], $tax_id );
@@ -227,18 +227,18 @@ add_action( 'edd_complete_purchase', 'edd_quaderno_create_invoice', 999 );
 */
 function edd_quaderno_process_recurring_payment( $order_id, $parent_id ) {
 	// we copy the tax ID from the original order
-	$tax_id = edd_get_order_meta( $parent_id, 'vat_number', true );
+	$tax_id = edd_quaderno_get_order_meta( $parent_id, 'vat_number', true );
 	if ( empty ( $tax_id ) ) {
-		$tax_id = edd_get_order_meta( $parent_id, 'tax_id', true );
+		$tax_id = edd_quaderno_get_order_meta( $parent_id, 'tax_id', true );
 	}
 	edd_add_order_meta( $order_id, 'tax_id', $tax_id );
 
 	// we copy the business name from the original order
-	$business_name = edd_get_order_meta( $parent_id, 'business_name', true );
+	$business_name = edd_quaderno_get_order_meta( $parent_id, 'business_name', true );
 	edd_add_order_meta( $order_id, 'business_name', $business_name );
 
 	// copy the IP address from the original order
-	$parent_order = edd_get_order( $parent_id );
+	$parent_order = edd_quaderno_get_order_meta( $parent_id );
 	edd_update_order( $order_id, array( 'ip' => $parent_order->ip ) );
 
 	// generate the invoice

--- a/includes/order_details.php
+++ b/includes/order_details.php
@@ -44,6 +44,26 @@ function edd_quaderno_add_payment_meta($payment_id) {
 add_action('edd_view_order_details_payment_meta_before', 'edd_quaderno_add_payment_meta', 100);
 
 /**
+* Call edd_get_order_meta with fallback to 'payment_meta'
+*
+* @since  1.26.0
+* @param  mixed $order_id
+* @param  string $key
+* @return @return mixed|void
+*/
+function edd_quaderno_get_order_meta($order_id, $key) {
+  $value = edd_get_order_meta( $order_id, $key, true );
+  if ( empty ( $value ) ) {
+    $payment_meta = edd_get_order_meta( $order_id, 'payment_meta', true );
+    if ( isset ( $payment_meta[$key] ) ) {
+      $value = $payment_meta[$key];
+    }
+  }
+
+  return $value;
+}
+
+/**
 * Add link to Quaderno invoice in payment details page
 *
 * @since  1.26.0

--- a/includes/order_details.php
+++ b/includes/order_details.php
@@ -44,7 +44,7 @@ function edd_quaderno_add_payment_meta($payment_id) {
 add_action('edd_view_order_details_payment_meta_before', 'edd_quaderno_add_payment_meta', 100);
 
 /**
-* Call edd_get_order_meta with fallback to 'payment_meta'
+* Call edd_get_order_meta with fallback to the payment meta
 *
 * @since  1.26.0
 * @param  mixed $order_id
@@ -54,10 +54,8 @@ add_action('edd_view_order_details_payment_meta_before', 'edd_quaderno_add_payme
 function edd_quaderno_get_order_meta($order_id, $key) {
   $value = edd_get_order_meta( $order_id, $key, true );
   if ( empty ( $value ) ) {
-    $payment_meta = edd_get_order_meta( $order_id, 'payment_meta', true );
-    if ( isset ( $payment_meta[$key] ) ) {
-      $value = $payment_meta[$key];
-    }
+    $payment = new EDD_Payment( $order_id );
+    $value = $payment->get_meta( $key );
   }
 
   return $value;

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Contributors: polimorfico
 Tags: tax, taxes, sales tax, vat, gst, vatmoss, vat moss, vat oss, oss, ioss, billing, invoices, receipts, credit notes, edd, easydigitaldownloads, easy digital downloads, quaderno
 Requires at least: 4.6
 Tested up to: 6.2
-Stable tag: 1.33.1
+Stable tag: 1.33.2
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -65,6 +65,9 @@ If you have any questions please get in touch with us at support@quaderno.io.
 4. Example of a receipt
 
 == Changelog ==
+
+= 1.33.2 – May 26, 2023 =
+* Fix: fallback to payment metadata searching in order metadata
 
 = 1.33.1 – May 1, 2023 =
 * Fix: warning message "Undefined index: clear_trasients"


### PR DESCRIPTION
Description same as title.

Overriding the `edd_get_order_meta` function to also check the `payment_meta` key.
